### PR TITLE
Automatic pyinstaller build via CI/CD

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        target: [x86_64, arm64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -54,24 +54,23 @@ jobs:
           name: noScribeEdit-win-${{ matrix.target }}
           path: dist
 
-  # macos:
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       target: [x86_64, aarch64]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.10'
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.target }}
-  #         args: --release --out dist --find-interpreter
-  #         sccache: 'true'
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wheels
-  #         path: dist
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          architecture: ${{ matrix.target }}
+      - name: Install pyinstaller
+        run: pip install pyinstaller
+      - name: Build package with pyinstaller
+        run: pyinstaller noScribeEdit-macOS.spec
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: noScribeEdit-macOS-${{ matrix.target }}
+          path: dist

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: ${{ matrix.target }}
       - name: Install pyinstaller
         run: pip install pyinstaller

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -44,6 +44,8 @@ jobs:
         with:
           python-version: '3.9'
           architecture: ${{ matrix.target }}
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install pyinstaller
         run: pip install pyinstaller
       - name: Build package with pyinstaller
@@ -65,6 +67,8 @@ jobs:
         with:
           python-version: '3.10'
           architecture: ${{ matrix.target }}
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install pyinstaller
         run: pip install pyinstaller
       - name: Build package with pyinstaller

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -1,0 +1,77 @@
+name: pyinstaller
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  # linux:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.target }}
+  #         args: --release --out dist --find-interpreter
+  #         sccache: 'true'
+  #         manylinux: auto
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          architecture: ${{ matrix.target }}
+      - name: Install pyinstaller
+        run: pip install pyinstaller
+      - name: Build package with pyinstaller
+        run: pyinstaller noScribeEdit.spec
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: noScribeEdit
+          path: dist
+
+  # macos:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       target: [x86_64, aarch64]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.target }}
+  #         args: --release --out dist --find-interpreter
+  #         sccache: 'true'
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: wheels
+  #         path: dist

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64, arm64]
+        target: [x64, arm64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -48,10 +48,10 @@ jobs:
         run: pip install pyinstaller
       - name: Build package with pyinstaller
         run: pyinstaller noScribeEdit.spec
-      - name: Upload wheels
+      - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: noScribeEdit
+          name: noScribeEdit-win-${{ matrix.target }}
           path: dist
 
   # macos:

--- a/noScribeEdit-macOS.spec
+++ b/noScribeEdit-macOS.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['noScribeEdit.py'],
+    pathex=[],
+    binaries=[('ffmpeg_mac/ffmpeg','ffmpeg_mac'),
+        ('ffmpeg_mac/ffplay','ffmpeg_mac')],
+    datas=[('noScribeEditLogo.png', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='noScribeEdit',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon='noScribeEditLogo.ico'
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='noScribeEdit',
+)

--- a/noScribeEdit.spec
+++ b/noScribeEdit.spec
@@ -7,9 +7,9 @@ block_cipher = None
 a = Analysis(
     ['noScribeEdit.py'],
     pathex=[],
-    binaries=[('C:/Users/kai/Documents/Programmierung/2023_WhisperTranscribe/noScribeEditor/ffmpeg_win/ffmpeg.exe','ffmpeg_win'),
-        ('C:/Users/kai/Documents/Programmierung/2023_WhisperTranscribe/noScribeEditor/ffmpeg_win/ffplay.exe','ffmpeg_win')],
-    datas=[('C:/Users/kai/Documents/Programmierung/2023_WhisperTranscribe/noScribeEditor/noScribeEditLogo.png', '.')],
+    binaries=[('ffmpeg_win/ffmpeg.exe','ffmpeg_win'),
+        ('ffmpeg_win/ffplay.exe','ffmpeg_win')],
+    datas=[('noScribeEditLogo.png', '.')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
Don't know if you find this useful but I made a ci/cd which automatically builds the executable and uploads them as a github artifact. In principle this works for all os's and architectures. I think this can also be linked to releases, so everything would be available for download via gh and automatically update on commit or release.

Currently, only windows build is enabled because linux is not merged yet and for macOS there was no `spec` file in the repo.

[Here](https://github.com/domna/noScribeEditor/actions/runs/6829243010) you see an example of the workflow run.