### PR TITLE
Improve audio playback pause responsiveness

### DIFF
--- a/noScribeEdit.py
+++ b/noScribeEdit.py
@@ -1015,7 +1015,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         self.keep_playing = True                            
                     except:
                         self.keep_playing = False # stop playing along  
-                sleep(0.1)
+                sleep(0.01)
                 self.play_along_action.blockSignals(True) 
                 self.play_along_action.setChecked(self.keep_playing)
                 self.play_along_action.blockSignals(False)


### PR DESCRIPTION
## Problem
The audio pause functionality (both pause button and clicking elsewhere in transcript) 
had a noticeable delay of up to 100ms before actually stopping playback. This made 
the controls feel unresponsive during audio editing workflows.

## Root Cause
The playback loop used `sleep(0.1)` between iterations, meaning the `keep_playing` 
flag was only checked every 100ms. When users clicked pause or moved the cursor, 
the audio would continue playing until the next loop iteration.

## Solution
Reduced the sleep interval from 100ms to 10ms (`sleep(0.01)`), making pause 
controls 10x more responsive with a maximum delay of 10ms instead of 100ms.

## Impact
- Pause button now responds within 10ms instead of 100ms
- Clicking elsewhere in transcript stops audio immediately
- Maintains all existing functionality including continuous segment playback
- No performance impact due to minimal sleep reduction

## Testing
- Verified continuous playback still works seamlessly across segments
- Confirmed both pause methods (button + cursor click) are now responsive
- Audio transitions remain smooth without gaps between segments